### PR TITLE
added stripPrefix to config example on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Filename for service worker.
 
 *Default:* `'sw.js'`
 
+##### stripPrefix [String]
+
+Removes a specified string from the beginning of path URL's at runtime.
+> [docs](https://github.com/GoogleChrome/sw-precache#stripprefix-string)
 
 ##### autorequire [Boolean, Array]
 
@@ -76,6 +80,7 @@ module.exports = {
     babel: {presets: ['es2015']},
     swPrecache: {
       'swFileName': 'service-worker.js',
+      'stripPrefix': 'public',
       'options': { 
         'staticFileGlobs': [
            'public/app.css',


### PR DESCRIPTION
added stripPrefix to allow runtime to cache assets as there is a difference to the build path. Added to config example and short description in Configuration.
